### PR TITLE
Add Posthog analytics script

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
     <meta name="msapplication-TileColor" content="#000000">
     <meta name="theme-color" content="#000000">
     <!--Zenon Network is an independent entity-->
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('phc_LlvOUrxWAJd4SVXX3twmynNFMhB7q2r2Y8vIhG6cLCX',{api_host:'https://app.posthog.com'})
+    </script>
 </head>
 
 <body class="animateBody">


### PR DESCRIPTION
Hi, John-Z here. 

As discussed in the Forum, I've added PostHog's plug-in to help with the product analytics of Zenon's website. 

PostHog is the open-source platform for product data that will help us track the website traffic through product analytics, session recording, feature flags, heatmaps, experiments and so much more.

It is free for the first 1 million sessions, so we have some time to see its usefulness. 

Hope it gets accepted. 

