### PR TITLE
Fix API price feed in top nav

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -93,12 +93,13 @@
     }
 })();
 
-$("document").ready(function() {
+$(document).ready(function() {
     $.get("https://api.coingecko.com/api/v3/simple/price?ids=zenon-2&vs_currencies=usd", function(data) {
-        $("#znn-price").text(data.['zenon-2'].usd.toFixed(2));
+        $("#znn-price").text(data['zenon-2'].usd.toFixed(2));
     });
+
     $.get("https://api.coingecko.com/api/v3/simple/price?ids=quasar-2&vs_currencies=usd", function(data) {
-        $("#qsr-price").text(data.['quasar-2'].usd.toFixed(2));
+        $("#qsr-price").text(data['quasar-2'].usd.toFixed(2));
     });
 
     $('.scroll').click(function() {

--- a/js/main.js
+++ b/js/main.js
@@ -95,10 +95,10 @@
 
 $("document").ready(function() {
     $.get("https://api.coingecko.com/api/v3/simple/price?ids=zenon-2&vs_currencies=usd", function(data) {
-        $("#znn-price").text(data.zenon-2.usd.toFixed(2));
+        $("#znn-price").text(data.['zenon-2'].usd.toFixed(2));
     });
     $.get("https://api.coingecko.com/api/v3/simple/price?ids=quasar-2&vs_currencies=usd", function(data) {
-        $("#qsr-price").text(data.quasar-2.usd.toFixed(2));
+        $("#qsr-price").text(data.['quasar-2'].usd.toFixed(2));
     });
 
     $('.scroll').click(function() {

--- a/js/main.js
+++ b/js/main.js
@@ -95,10 +95,10 @@
 
 $("document").ready(function() {
     $.get("https://api.coingecko.com/api/v3/simple/price?ids=zenon-2&vs_currencies=usd", function(data) {
-        $("#znn-price").text(data.zenon.usd.toFixed(2));
+        $("#znn-price").text(data.zenon-2.usd.toFixed(2));
     });
     $.get("https://api.coingecko.com/api/v3/simple/price?ids=quasar-2&vs_currencies=usd", function(data) {
-        $("#qsr-price").text(data.quasar.usd.toFixed(2));
+        $("#qsr-price").text(data.quasar-2.usd.toFixed(2));
     });
 
     $('.scroll').click(function() {

--- a/js/main.js
+++ b/js/main.js
@@ -94,10 +94,10 @@
 })();
 
 $("document").ready(function() {
-    $.get("https://api.coingecko.com/api/v3/simple/price?ids=zenon&vs_currencies=usd", function(data) {
+    $.get("https://api.coingecko.com/api/v3/simple/price?ids=zenon-2&vs_currencies=usd", function(data) {
         $("#znn-price").text(data.zenon.usd.toFixed(2));
     });
-    $.get("https://api.coingecko.com/api/v3/simple/price?ids=quasar&vs_currencies=usd", function(data) {
+    $.get("https://api.coingecko.com/api/v3/simple/price?ids=quasar-2&vs_currencies=usd", function(data) {
         $("#qsr-price").text(data.quasar.usd.toFixed(2));
     });
 


### PR DESCRIPTION
Update the token ID  to zenon-2 and quasar-2 in order for the API to pull the price data from CoinCecko.